### PR TITLE
Konfigurationen per ID speichern/laden + kompakte Club-Ansicht

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -55,6 +55,8 @@ const COOKIE_RECENT       = 'pb_recent';
 const COOKIE_VENUES       = 'pb_venues';
 const COOKIE_VIEW         = 'pb_view';
 const COOKIE_EXTRA_CLUBS  = 'pb_extra_clubs';
+const SAVED_CONFIGS_KEY   = 'pb_saved_configs_v1';
+const URL_CONFIG_PARAM    = 'config';
 
 const VENUE_COLORS = [
   '#1565c0', '#6a1b9a', '#e65100', '#00695c',
@@ -97,6 +99,8 @@ const state = {
   view: 'week',
   loadedFrom: '',
   loadedTo: '',
+  activeConfigId: '',
+  compactClubSelection: false,
 };
 
 const $ = id => document.getElementById(id);
@@ -755,6 +759,33 @@ function updateSectionVisibility() {
   showEl($('section-kalender'), hasClub);
 }
 
+function renderCompactClubSelection() {
+  const compactEl = $('selected-club-compact');
+  const logosEl = $('selected-club-compact-logos');
+  const dialogEl = $('club-selection-dialog');
+  if (!compactEl || !logosEl || !dialogEl) return;
+  const allClubs = getAllClubs();
+  const showCompact = !!(state.compactClubSelection && allClubs.length > 0);
+  if (!showCompact) {
+    showEl(compactEl, false);
+    showEl(dialogEl, true);
+    return;
+  }
+  logosEl.innerHTML = allClubs.map(club => (
+    club.logoUrl
+      ? '<img class="selected-club-compact-logo" src="' + escapeHtml(club.logoUrl) + '" alt="' + escapeHtml(club.name || club.id) + '" title="' + escapeHtml(club.name || club.id) + '" loading="lazy">'
+      : '<span class="selected-club-compact-fallback" title="' + escapeHtml(club.name || club.id) + '">' + escapeHtml((club.name || '?').charAt(0).toUpperCase()) + '</span>'
+  )).join('');
+  showEl(compactEl, true);
+  showEl(dialogEl, false);
+}
+
+function jumpToCalendar() {
+  const calendarSection = $('section-kalender');
+  if (!calendarSection) return;
+  calendarSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
 // ===================== Cookie Persistence =====================
 
 function loadFromCookies() {
@@ -793,6 +824,114 @@ function saveVenuesCookie() {
   } else {
     setCookie(COOKIE_VENUES, state.selectedVenueIds);
   }
+}
+
+// ===================== Saved Club Configurations =====================
+
+function readSavedConfigs() {
+  try {
+    const raw = localStorage.getItem(SAVED_CONFIGS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function writeSavedConfigs(configs) {
+  try {
+    localStorage.setItem(SAVED_CONFIGS_KEY, JSON.stringify(configs || {}));
+  } catch (_) {}
+}
+
+function sanitizeConfigId(value) {
+  return String(value || '').trim().toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 12);
+}
+
+function generateConfigId() {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  let out = '';
+  for (let i = 0; i < 6; i += 1) out += chars.charAt(Math.floor(Math.random() * chars.length));
+  return out;
+}
+
+function updateUrlConfigParam(configId) {
+  const url = new URL(window.location.href);
+  if (configId) url.searchParams.set(URL_CONFIG_PARAM, configId);
+  else url.searchParams.delete(URL_CONFIG_PARAM);
+  window.history.replaceState({}, '', url.toString());
+}
+
+function showConfigStatus(message, isError = false) {
+  const el = $('club-config-status');
+  if (!el) return;
+  el.textContent = message || '';
+  el.classList.toggle('error-msg', !!(message && isError));
+  showEl(el, !!message);
+}
+
+function applyClubConfig(configId, config, compactMode = false) {
+  if (!config || !config.club || !config.club.id) return false;
+  state.club = config.club;
+  state.additionalClubs = Array.isArray(config.additionalClubs) ? config.additionalClubs : [];
+  state.activeConfigId = configId || '';
+  state.compactClubSelection = !!compactMode;
+  state.games = [];
+  state.venues = [];
+  state.venueShortNames = {};
+  state.loadedFrom = '';
+  state.loadedTo = '';
+  state.selectedVenueIds = null;
+  saveClubCookie();
+  saveAdditionalClubsCookie();
+  saveVenuesCookie();
+  renderSelectedClub();
+  renderRecentClubs();
+  updateSectionVisibility();
+  renderVenueCheckboxes();
+  setTeamOverviewLoading();
+  hideSGSuggestion();
+  renderCompactClubSelection();
+  return true;
+}
+
+function loadConfigById(configId, compactMode = false) {
+  const cleanId = sanitizeConfigId(configId);
+  if (!cleanId) return false;
+  const configs = readSavedConfigs();
+  const config = configs[cleanId];
+  if (!config) return false;
+  const applied = applyClubConfig(cleanId, config, compactMode);
+  if (!applied) return false;
+  const input = $('club-config-id-input');
+  if (input) input.value = cleanId;
+  updateUrlConfigParam(cleanId);
+  return true;
+}
+
+function saveCurrentConfig() {
+  const allClubs = getAllClubs();
+  if (!allClubs.length) {
+    showConfigStatus('Bitte zuerst mindestens einen Verein auswählen.', true);
+    return;
+  }
+  const input = $('club-config-id-input');
+  let configId = sanitizeConfigId(input ? input.value : '');
+  const configs = readSavedConfigs();
+  if (!configId) {
+    do { configId = generateConfigId(); } while (configs[configId]);
+  }
+  configs[configId] = {
+    club: state.club,
+    additionalClubs: state.additionalClubs,
+    updatedAt: new Date().toISOString(),
+  };
+  writeSavedConfigs(configs);
+  state.activeConfigId = configId;
+  updateUrlConfigParam(configId);
+  if (input) input.value = configId;
+  showConfigStatus('Konfiguration gespeichert: ' + configId);
 }
 
 // ===================== Recent Clubs =====================
@@ -858,6 +997,8 @@ function renderRecentClubs() {
 function selectClub(club) {
   state.club = club;
   state.additionalClubs = [];
+  state.activeConfigId = '';
+  state.compactClubSelection = false;
   state.games = [];
   state.venues = [];
   state.venueShortNames = {};
@@ -868,7 +1009,10 @@ function selectClub(club) {
   saveAdditionalClubsCookie();
   saveRecentClub(club);
   saveVenuesCookie();
+  updateUrlConfigParam('');
+  showConfigStatus('');
   renderSelectedClub();
+  renderCompactClubSelection();
   renderRecentClubs();
   updateSectionVisibility();
   renderVenueCheckboxes();
@@ -931,6 +1075,8 @@ function renderSelectedClub() {
 function clearClub() {
   state.club = null;
   state.additionalClubs = [];
+  state.activeConfigId = '';
+  state.compactClubSelection = false;
   state.games = [];
   state.venues = [];
   state.venueShortNames = {};
@@ -940,8 +1086,11 @@ function clearClub() {
   saveClubCookie();
   saveAdditionalClubsCookie();
   saveVenuesCookie();
+  updateUrlConfigParam('');
+  showConfigStatus('');
   sessionStorage.removeItem(SESSION_KEY);
   renderSelectedClub();
+  renderCompactClubSelection();
   renderVenueCheckboxes();
   updateSectionVisibility();
   hideSGSuggestion();
@@ -1420,8 +1569,13 @@ async function addAdditionalClub(club) {
     logoUrl: club.logoUrl || '',
     url: club.url || '',
   });
+  state.activeConfigId = '';
+  state.compactClubSelection = false;
+  updateUrlConfigParam('');
   saveAdditionalClubsCookie();
+  showConfigStatus('');
   renderSelectedClub();
+  renderCompactClubSelection();
   hideSGSuggestion();
   const dateFrom = state.loadedFrom || getDefaultDateRange().dateFrom;
   const dateTo   = state.loadedTo   || getDefaultDateRange().dateTo;
@@ -1443,8 +1597,13 @@ async function removeSelectedClub(clubId) {
   } else {
     state.additionalClubs = state.additionalClubs.filter(c => c.id !== clubId);
   }
+  state.activeConfigId = '';
+  state.compactClubSelection = false;
+  updateUrlConfigParam('');
   saveAdditionalClubsCookie();
+  showConfigStatus('');
   renderSelectedClub();
+  renderCompactClubSelection();
   const dateFrom = state.loadedFrom || getDefaultDateRange().dateFrom;
   const dateTo   = state.loadedTo   || getDefaultDateRange().dateTo;
   await fetchGames(dateFrom, dateTo);
@@ -1871,6 +2030,45 @@ function goToDate(dateStr) {
 // ===================== Event Binding =====================
 
 function bindEvents() {
+  const saveConfigBtn = $('save-club-config-btn');
+  if (saveConfigBtn) saveConfigBtn.addEventListener('click', saveCurrentConfig);
+  const loadConfigBtn = $('load-club-config-btn');
+  if (loadConfigBtn) {
+    loadConfigBtn.addEventListener('click', async () => {
+      const input = $('club-config-id-input');
+      const configId = sanitizeConfigId(input ? input.value : '');
+      if (!configId) {
+        showConfigStatus('Bitte eine Konfig-ID eingeben.', true);
+        return;
+      }
+      showConfigStatus('');
+      const ok = loadConfigById(configId, true);
+      if (!ok) {
+        showConfigStatus('Keine Konfiguration mit ID "' + configId + '" gefunden.', true);
+        return;
+      }
+      await autoLoadGames();
+      jumpToCalendar();
+      showConfigStatus('Konfiguration geladen: ' + configId);
+    });
+  }
+  const configInput = $('club-config-id-input');
+  if (configInput && loadConfigBtn) {
+    configInput.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        loadConfigBtn.click();
+      }
+    });
+  }
+  const changeBtn = $('selected-club-change-btn');
+  if (changeBtn) {
+    changeBtn.addEventListener('click', () => {
+      state.compactClubSelection = false;
+      renderCompactClubSelection();
+    });
+  }
+
   $('club-search-btn').addEventListener('click', () => {
     const query = $('club-search-input').value.trim();
     if (query.length < 2) {
@@ -1927,7 +2125,16 @@ async function init() {
   state.currentWeekStart = getMonday(today);
   state.currentMonth     = new Date(today.getFullYear(), today.getMonth(), 1);
 
+  const requestedConfigId = sanitizeConfigId(new URLSearchParams(window.location.search).get(URL_CONFIG_PARAM) || '');
+  if (requestedConfigId) {
+    if (!loadConfigById(requestedConfigId, true)) {
+      showConfigStatus('Konfiguration "' + requestedConfigId + '" wurde nicht gefunden.', true);
+      updateUrlConfigParam('');
+    }
+  }
+
   renderSelectedClub();
+  renderCompactClubSelection();
   renderRecentClubs();
   updateSectionVisibility();
   bindEvents();
@@ -1937,6 +2144,7 @@ async function init() {
 
   if (state.club && state.club.id) {
     await autoLoadGames();
+    if (requestedConfigId && state.compactClubSelection) jumpToCalendar();
   } else {
     renderVenueCheckboxes();
     renderTeamOverview();

--- a/public/app.js
+++ b/public/app.js
@@ -99,7 +99,6 @@ const state = {
   view: 'week',
   loadedFrom: '',
   loadedTo: '',
-  activeConfigId: '',
   compactClubSelection: false,
 };
 
@@ -868,6 +867,7 @@ function showConfigStatus(message, isError = false) {
   if (!el) return;
   el.textContent = message || '';
   el.classList.toggle('error-msg', !!(message && isError));
+  el.classList.toggle('current-club', !(message && isError));
   showEl(el, !!message);
 }
 
@@ -875,7 +875,6 @@ function applyClubConfig(configId, config, compactMode = false) {
   if (!config || !config.club || !config.club.id) return false;
   state.club = config.club;
   state.additionalClubs = Array.isArray(config.additionalClubs) ? config.additionalClubs : [];
-  state.activeConfigId = configId || '';
   state.compactClubSelection = !!compactMode;
   state.games = [];
   state.venues = [];
@@ -928,7 +927,6 @@ function saveCurrentConfig() {
     updatedAt: new Date().toISOString(),
   };
   writeSavedConfigs(configs);
-  state.activeConfigId = configId;
   updateUrlConfigParam(configId);
   if (input) input.value = configId;
   showConfigStatus('Konfiguration gespeichert: ' + configId);
@@ -997,7 +995,6 @@ function renderRecentClubs() {
 function selectClub(club) {
   state.club = club;
   state.additionalClubs = [];
-  state.activeConfigId = '';
   state.compactClubSelection = false;
   state.games = [];
   state.venues = [];
@@ -1075,7 +1072,6 @@ function renderSelectedClub() {
 function clearClub() {
   state.club = null;
   state.additionalClubs = [];
-  state.activeConfigId = '';
   state.compactClubSelection = false;
   state.games = [];
   state.venues = [];
@@ -1569,7 +1565,6 @@ async function addAdditionalClub(club) {
     logoUrl: club.logoUrl || '',
     url: club.url || '',
   });
-  state.activeConfigId = '';
   state.compactClubSelection = false;
   updateUrlConfigParam('');
   saveAdditionalClubsCookie();
@@ -1597,7 +1592,6 @@ async function removeSelectedClub(clubId) {
   } else {
     state.additionalClubs = state.additionalClubs.filter(c => c.id !== clubId);
   }
-  state.activeConfigId = '';
   state.compactClubSelection = false;
   updateUrlConfigParam('');
   saveAdditionalClubsCookie();

--- a/public/index.html
+++ b/public/index.html
@@ -149,8 +149,8 @@
           />
           <button id="load-club-config-btn" class="btn btn-secondary" type="button">Konfiguration laden</button>
         </div>
-        <div id="club-config-status" class="hint current-club hidden"></div>
       </div>
+      <div id="club-config-status" class="hint current-club hidden"></div>
       <!-- public inline submit form removed; use modal +Training in cards / team rows -->
 
       <!-- Modal is rendered at document root to avoid clipping and ensure correct overlay behavior -->

--- a/public/index.html
+++ b/public/index.html
@@ -44,18 +44,23 @@
           <span class="tooltip-content">Vereinslink von fussball.de einfügen oder Vereinsnamen eingeben. Die Auswahl wird im Browser gespeichert (Cookie).</span>
         </span>
       </h2>
-      <div id="recent-clubs" class="recent-clubs hidden"></div>
-      <div class="input-row">
-        <input
-          type="text"
-          id="club-search-input"
-          placeholder="Vereinsname oder fussball.de Verein-Link…"
-          autocomplete="off"
-        />
-        <button id="club-search-btn" class="btn btn-primary">Suchen</button>
+      <div id="selected-club-compact" class="selected-club-compact hidden">
+        <div id="selected-club-compact-logos" class="selected-club-compact-logos"></div>
+        <button id="selected-club-change-btn" class="btn btn-sm btn-secondary" type="button">ändern</button>
       </div>
-      <div id="club-search-results" class="search-results hidden"></div>
-      <div id="selected-club-info" class="selected-club-info">
+      <div id="club-selection-dialog">
+        <div id="recent-clubs" class="recent-clubs hidden"></div>
+        <div class="input-row">
+          <input
+            type="text"
+            id="club-search-input"
+            placeholder="Vereinsname oder fussball.de Verein-Link…"
+            autocomplete="off"
+          />
+          <button id="club-search-btn" class="btn btn-primary">Suchen</button>
+        </div>
+        <div id="club-search-results" class="search-results hidden"></div>
+        <div id="selected-club-info" class="selected-club-info">
         <div class="selected-club-label">Ausgewählte Vereine</div>
         <div class="selected-club-cards">
           <div class="selected-club-card">
@@ -100,8 +105,8 @@
             </div>
           </div>
         </div>
-      </div>
-      <div id="sg-suggestion" class="sg-suggestion">
+        </div>
+        <div id="sg-suggestion" class="sg-suggestion">
         <div class="sg-suggestion-icon">🤝</div>
         <div class="sg-suggestion-body">
           <div class="sg-suggestion-title">Spielgemeinschaft erkannt</div>
@@ -116,8 +121,8 @@
           </div>
         </div>
         <button class="sg-dismiss-btn" type="button" aria-label="Schließen">×</button>
-      </div>
-      <details id="team-overview" class="team-overview">
+        </div>
+        <details id="team-overview" class="team-overview">
         <summary><span id="team-overview-summary">▸ 7 Mannschaften</span></summary>
         <div id="team-overview-loading" class="loading hidden">
           <span class="spinner"></span> Mannschaften werden geladen…
@@ -132,7 +137,20 @@
           <div class="team-overview-table"><span class="team-overview-name">SGM SKV Hochberg/SGV Hochdorf I</span><span class="team-overview-comp">E-Junioren | Kreisstaffel</span><span class="team-overview-actions"><button class="btn btn-sm" title="+ Training" aria-label="Training melden">+ Training</button></span></div>
           <div class="team-overview-table"><span class="team-overview-name">SGM SKV Hochberg/SGV Hochdorf II</span><span class="team-overview-comp">E-Junioren | Kreisstaffel</span><span class="team-overview-actions"><button class="btn btn-sm" title="+ Training" aria-label="Training melden">+ Training</button></span></div>
         </div>
-      </details>
+        </details>
+        <div class="config-actions">
+          <button id="save-club-config-btn" class="btn btn-secondary" type="button">Konfiguration speichern</button>
+          <input
+            type="text"
+            id="club-config-id-input"
+            class="config-id-input"
+            placeholder="Konfig-ID"
+            autocomplete="off"
+          />
+          <button id="load-club-config-btn" class="btn btn-secondary" type="button">Konfiguration laden</button>
+        </div>
+        <div id="club-config-status" class="hint current-club hidden"></div>
+      </div>
       <!-- public inline submit form removed; use modal +Training in cards / team rows -->
 
       <!-- Modal is rendered at document root to avoid clipping and ensure correct overlay behavior -->

--- a/public/style.css
+++ b/public/style.css
@@ -607,6 +607,64 @@ main {
   margin-top: 0.8rem;
 }
 
+.selected-club-compact {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #f7fbf8;
+  margin-top: 0.2rem;
+}
+
+.selected-club-compact-logos {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.selected-club-compact-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: contain;
+  background: var(--white);
+  border: 1px solid var(--border);
+}
+
+.selected-club-compact-fallback {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--primary-l);
+  color: var(--primary-d);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  font-weight: 700;
+  border: 1px solid var(--border);
+}
+
+.config-actions {
+  margin-top: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.config-id-input {
+  min-width: 150px;
+  max-width: 190px;
+  padding: 0.52rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
 .selected-club-label {
   font-size: 0.78rem;
   color: var(--text-light);


### PR DESCRIPTION
### Motivation
- Nutzer sollen eine Auswahl von Spielgemeinschafts-Vereinen als wiederverwendbare Konfiguration speichern und per ID wiederherstellen können, wobei beim Laden nur die Logos oben angezeigt werden und ein „ändern“-Button das volle Dialogfeld wieder öffnet.
- Beim Aufruf einer gespeicherten Konfiguration soll direkt zum Belegungskalender gesprungen werden, damit Anwender sofort die Belegung sehen.

### Description
- Implementiert Save/Load-Flow in `public/app.js` mit Persistenz in `localStorage` unter dem Schlüssel `pb_saved_configs_v1`, ID-Generierung/Normalisierung sowie URL-Sync über `?config=<ID>`. 
- Ergänzt UI in `public/index.html` für kompakte Anzeige (`selected-club-compact`), „ändern“-Button, sowie Controls zum `Konfiguration speichern` / `Konfiguration laden` und ein Eingabefeld für die Konfig-ID. 
- Fügt Styles in `public/style.css` für die kompakte Logo-Ansicht, Fallback-Logos und die Konfigurations-Controls hinzu. 
- Beim Laden einer Konfiguration werden Hauptverein + Zusatzvereine gesetzt, die UI in die kompakte Ansicht versetzt, `autoLoadGames` ausgelöst und (falls kompakt geladen) automatisch zum Kalender gescrollt; Änderungen am Auswahlzustand löschen die aktive Konfig-ID und entfernen den URL-Parameter. 

### Testing
- Statische Prüfung mit `node --check public/app.js` wurde erfolgreich ausgeführt. 
- Node/NPM smoke test `npm test` lief erfolgreich. 
- Python-Tests wurden mit `PYTHONPATH=src pytest -q` ausgeführt und alle Tests sind erfolgreich (`128 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40ceda1e88320a7e0a4b1f8b443cf)