### PR TITLE
Add admin dashboard, page-hits tracking and recent-config UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,14 @@ php -S 0.0.0.0:3210 backend.php
 | Endpunkt | Beschreibung |
 |---|---|
 | `GET /` | Web-UI (public/index.html) |
+| `GET /admin` | Passwortgeschützte Admin-Webseite (Statistik, Page Hits, Konfiguration) |
 | `GET /api/snapshot` | Vollständiger aktuellster Snapshot (JSON) |
 | `GET /api/games?venueId=ID` | Spiele einer oder mehrerer Sportstätten |
 | `GET /api/search?q=Name` | Sportstätten auf fussball.de suchen |
 | `GET /api/admin/club-parse-stats?password=...` | Anonyme Nutzungsstatistik pro Verein (sortiert nach Parse-Anzahl) |
+| `GET /api/admin/config?password=...` | Vollständige bestehende `config.yaml` (passwortgeschützt) |
+| `GET /api/admin/page-hits?password=...` | Aggregierte Seitenaufrufe pro Pfad |
+| `GET /api/admin/dashboard?password=...` | Kombinierte Admin-Daten (Statistik, Page Hits, Konfiguration) |
 | `GET /api/demo` | Demo-Daten (kein Snapshot erforderlich) |
 
 Für die Statistik muss serverseitig ein Passwort gesetzt sein (nicht im Git):

--- a/backend.php
+++ b/backend.php
@@ -9,6 +9,7 @@ const CONFIG_FILE = __DIR__ . '/config.yaml';
 const VERSION_FILE = __DIR__ . '/VERSION';
 const BUILD_META_FILE = __DIR__ . '/BUILD_META.json';
 const USAGE_STATS_FILE = DATA_DIR . '/club_parse_stats.json';
+const PAGE_HITS_FILE = DATA_DIR . '/page_hits.json';
 const STATS_PASSWORD_FILE = __DIR__ . '/.stats_password';
 const APP_REPOSITORY_URL = 'https://github.com/MNLBCK/Platzbelegung';
 const APP_RELEASES_URL = APP_REPOSITORY_URL . '/releases/tag/';
@@ -245,6 +246,18 @@ function loadStatsPassword(): string
     return $raw;
 }
 
+function ensureStatsPasswordAuthorized(string $providedPassword): ?array
+{
+    $expectedPassword = loadStatsPassword();
+    if ($expectedPassword === '') {
+        return ['error' => 'Stats-Passwort ist nicht konfiguriert.', 'status' => 503];
+    }
+    if (!hash_equals($expectedPassword, $providedPassword)) {
+        return ['error' => 'Unauthorized', 'status' => 401];
+    }
+    return null;
+}
+
 function loadUsageStats(): array
 {
     if (!is_file(USAGE_STATS_FILE)) {
@@ -275,6 +288,82 @@ function saveUsageStats(array $stats): bool
         return false;
     }
     return file_put_contents(USAGE_STATS_FILE, $json . PHP_EOL, LOCK_EX) !== false;
+}
+
+function loadPageHits(): array
+{
+    if (!is_file(PAGE_HITS_FILE)) {
+        return ['updatedAt' => null, 'total' => 0, 'paths' => []];
+    }
+    $raw = file_get_contents(PAGE_HITS_FILE);
+    if ($raw === false) {
+        return ['updatedAt' => null, 'total' => 0, 'paths' => []];
+    }
+    $parsed = json_decode($raw, true);
+    if (!is_array($parsed)) {
+        return ['updatedAt' => null, 'total' => 0, 'paths' => []];
+    }
+    $paths = $parsed['paths'] ?? [];
+    if (!is_array($paths)) {
+        $paths = [];
+    }
+    return [
+        'updatedAt' => $parsed['updatedAt'] ?? null,
+        'total' => (int)($parsed['total'] ?? 0),
+        'paths' => $paths,
+    ];
+}
+
+function savePageHits(array $hits): bool
+{
+    if (!is_dir(DATA_DIR) && !mkdir(DATA_DIR, 0775, true) && !is_dir(DATA_DIR)) {
+        return false;
+    }
+    $json = json_encode($hits, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    if ($json === false) {
+        return false;
+    }
+    return file_put_contents(PAGE_HITS_FILE, $json . PHP_EOL, LOCK_EX) !== false;
+}
+
+function shouldTrackPageHit(string $uri): bool
+{
+    if (str_starts_with($uri, '/api/admin/')) {
+        return false;
+    }
+    if ($uri === '/admin' || $uri === '/admin.html') {
+        return false;
+    }
+    return true;
+}
+
+function recordPageHit(string $uri): void
+{
+    if (!shouldTrackPageHit($uri)) {
+        return;
+    }
+    $hits = loadPageHits();
+    $paths = $hits['paths'] ?? [];
+    $paths[$uri] = ((int)($paths[$uri] ?? 0)) + 1;
+    arsort($paths);
+    $hits['paths'] = $paths;
+    $hits['total'] = ((int)($hits['total'] ?? 0)) + 1;
+    $hits['updatedAt'] = gmdate(DATE_ATOM);
+    savePageHits($hits);
+}
+
+function buildPageHitsResponse(array $hits): array
+{
+    $paths = [];
+    foreach (($hits['paths'] ?? []) as $path => $count) {
+        $paths[] = ['path' => (string)$path, 'hits' => (int)$count];
+    }
+    usort($paths, fn(array $a, array $b): int => ($b['hits'] <=> $a['hits']) ?: strcmp($a['path'], $b['path']));
+    return [
+        'updatedAt' => $hits['updatedAt'] ?? null,
+        'total' => (int)($hits['total'] ?? 0),
+        'paths' => $paths,
+    ];
 }
 
 function recordClubParse(string $clubId, string $clubName = '', string $clubLogoUrl = '', string $clubLocation = ''): void
@@ -691,6 +780,7 @@ function getJsonBody(): array
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 $uri = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
 parse_str(parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_QUERY) ?: '', $query);
+recordPageHit($uri);
 
 // Public POST endpoint for submitting requests must be handled regardless of GET/HEAD block.
 if ($method === 'POST' && $uri === '/api/requests/submit') {
@@ -870,16 +960,56 @@ if (($method === 'GET' || $method === 'HEAD') && str_starts_with($uri, '/api/'))
 
     if ($uri === '/api/admin/club-parse-stats') {
         $providedPassword = (string)($query['password'] ?? '');
-        $expectedPassword = loadStatsPassword();
-        if ($expectedPassword === '') {
-            jsonResponse(['error' => 'Stats-Passwort ist nicht konfiguriert.'], 503);
-            return;
-        }
-        if (!hash_equals($expectedPassword, $providedPassword)) {
-            jsonResponse(['error' => 'Unauthorized'], 401);
+        $authError = ensureStatsPasswordAuthorized($providedPassword);
+        if ($authError !== null) {
+            jsonResponse(['error' => $authError['error']], (int)$authError['status']);
             return;
         }
         jsonResponse(buildStatsResponse(loadUsageStats()));
+        return;
+    }
+
+    if ($uri === '/api/admin/config') {
+        $providedPassword = (string)($query['password'] ?? '');
+        $authError = ensureStatsPasswordAuthorized($providedPassword);
+        if ($authError !== null) {
+            jsonResponse(['error' => $authError['error']], (int)$authError['status']);
+            return;
+        }
+        $config = loadConfig();
+        if ($config === null) {
+            jsonResponse(['error' => 'config.yaml nicht gefunden.'], 404);
+            return;
+        }
+        jsonResponse($config);
+        return;
+    }
+
+    if ($uri === '/api/admin/page-hits') {
+        $providedPassword = (string)($query['password'] ?? '');
+        $authError = ensureStatsPasswordAuthorized($providedPassword);
+        if ($authError !== null) {
+            jsonResponse(['error' => $authError['error']], (int)$authError['status']);
+            return;
+        }
+        jsonResponse(buildPageHitsResponse(loadPageHits()));
+        return;
+    }
+
+    if ($uri === '/api/admin/dashboard') {
+        $providedPassword = (string)($query['password'] ?? '');
+        $authError = ensureStatsPasswordAuthorized($providedPassword);
+        if ($authError !== null) {
+            jsonResponse(['error' => $authError['error']], (int)$authError['status']);
+            return;
+        }
+        $config = loadConfig();
+        jsonResponse([
+            'stats' => buildStatsResponse(loadUsageStats()),
+            'pageHits' => buildPageHitsResponse(loadPageHits()),
+            'config' => $config === null ? null : $config,
+            'configAvailable' => $config !== null,
+        ]);
         return;
     }
 
@@ -953,6 +1083,9 @@ if ($method === 'PUT' && $uri === '/api/config/venues') {
 
 if (($method === 'GET' || $method === 'HEAD') && ($uri === '/' || !str_starts_with($uri, '/api/'))) {
     $file = $uri === '/' ? '/index.html' : $uri;
+    if ($uri === '/admin') {
+        $file = '/admin.html';
+    }
     $path = realpath(__DIR__ . '/public' . $file);
     $public = realpath(__DIR__ . '/public');
     if ($path && $public && str_starts_with($path, $public) && is_file($path)) {

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Platzbelegung – Admin</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; background: #f5f7fb; color: #122; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 24px; }
+    .card { background: #fff; border: 1px solid #dbe3f0; border-radius: 12px; padding: 16px; margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.04); }
+    h1, h2 { margin: 0 0 12px; }
+    .row { display: flex; gap: 8px; flex-wrap: wrap; }
+    input, button { padding: 10px 12px; border-radius: 8px; border: 1px solid #b8c7e0; font: inherit; }
+    input { min-width: 280px; }
+    button { background: #1f63ff; color: white; border: none; cursor: pointer; }
+    button:hover { background: #154ed0; }
+    .muted { color: #567; font-size: 14px; }
+    .error { color: #b00020; margin-top: 8px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { text-align: left; padding: 8px; border-bottom: 1px solid #e4eaf5; font-size: 14px; }
+    pre { background: #0f172a; color: #e2e8f0; padding: 12px; border-radius: 8px; overflow: auto; font-size: 13px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Admin Dashboard</h1>
+    <div class="card">
+      <h2>Login</h2>
+      <div class="row">
+        <input id="password" type="password" placeholder="Admin-Passwort" />
+        <button id="load">Daten laden</button>
+      </div>
+      <div class="muted">Verwendet das gleiche Passwort wie <code>/api/admin/club-parse-stats</code>.</div>
+      <div id="error" class="error"></div>
+    </div>
+
+    <div id="content" style="display:none">
+      <div class="card">
+        <h2>Statistik</h2>
+        <div id="stats-meta" class="muted"></div>
+        <table>
+          <thead><tr><th>Verein</th><th>ID</th><th>Parses</th><th>Zuletzt</th></tr></thead>
+          <tbody id="stats-body"></tbody>
+        </table>
+      </div>
+
+      <div class="card">
+        <h2>Page Hits</h2>
+        <div id="hits-meta" class="muted"></div>
+        <table>
+          <thead><tr><th>Pfad</th><th>Hits</th></tr></thead>
+          <tbody id="hits-body"></tbody>
+        </table>
+      </div>
+
+      <div class="card">
+        <h2>Gespeicherte Konfiguration</h2>
+        <pre id="config-json"></pre>
+      </div>
+    </div>
+  </div>
+  <script src="/admin.js"></script>
+</body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,83 @@
+(function () {
+  const $ = (id) => document.getElementById(id);
+
+  function fmt(value) {
+    if (!value) return '-';
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? String(value) : d.toLocaleString('de-DE');
+  }
+
+  function setError(msg) {
+    $('error').textContent = msg || '';
+  }
+
+  function renderStats(stats) {
+    const body = $('stats-body');
+    body.innerHTML = '';
+    (stats.clubs || []).forEach((club) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td>' + (club.name || '-') + '</td>' +
+        '<td><code>' + (club.id || '-') + '</code></td>' +
+        '<td>' + (club.parses || 0) + '</td>' +
+        '<td>' + fmt(club.lastParsedAt) + '</td>';
+      body.appendChild(tr);
+    });
+    $('stats-meta').textContent = 'Gesamt: ' + (stats.totalParses || 0) + ' Parses, ' +
+      (stats.totalClubs || 0) + ' Vereine, aktualisiert: ' + fmt(stats.updatedAt);
+  }
+
+  function renderHits(hits) {
+    const body = $('hits-body');
+    body.innerHTML = '';
+    (hits.paths || []).forEach((row) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td><code>' + (row.path || '/') + '</code></td><td>' + (row.hits || 0) + '</td>';
+      body.appendChild(tr);
+    });
+    $('hits-meta').textContent = 'Gesamt: ' + (hits.total || 0) + ' Hits, aktualisiert: ' + fmt(hits.updatedAt);
+  }
+
+  async function loadDashboard() {
+    const password = $('password').value.trim();
+    if (!password) {
+      setError('Bitte Passwort eingeben.');
+      return;
+    }
+    setError('');
+
+    const url = '/api/admin/dashboard?password=' + encodeURIComponent(password);
+    let response;
+    try {
+      response = await fetch(url, { headers: { Accept: 'application/json' } });
+    } catch (e) {
+      setError('Netzwerkfehler beim Laden der Admin-Daten.');
+      return;
+    }
+
+    let data = {};
+    try {
+      data = await response.json();
+    } catch (e) {
+      setError('Ungültige Server-Antwort.');
+      return;
+    }
+
+    if (!response.ok) {
+      setError(data.error || ('Fehler: HTTP ' + response.status));
+      return;
+    }
+
+    renderStats(data.stats || {});
+    renderHits(data.pageHits || {});
+    $('config-json').textContent = JSON.stringify(data.config || {}, null, 2);
+    $('content').style.display = 'block';
+  }
+
+  $('load').addEventListener('click', loadDashboard);
+  $('password').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      loadDashboard();
+    }
+  });
+})();

--- a/public/app.js
+++ b/public/app.js
@@ -56,6 +56,7 @@ const COOKIE_VENUES       = 'pb_venues';
 const COOKIE_VIEW         = 'pb_view';
 const COOKIE_EXTRA_CLUBS  = 'pb_extra_clubs';
 const SAVED_CONFIGS_KEY   = 'pb_saved_configs_v1';
+const RECENT_CONFIGS_KEY  = 'pb_recent_configs_v1';
 const URL_CONFIG_PARAM    = 'config';
 
 const VENUE_COLORS = [
@@ -754,7 +755,6 @@ function renderTeamOverview() {
 
 function updateSectionVisibility() {
   const hasClub = !!(state.club && state.club.id);
-  showEl($('section-spielstaetten'), hasClub);
   showEl($('section-kalender'), hasClub);
 }
 
@@ -844,6 +844,41 @@ function writeSavedConfigs(configs) {
   } catch (_) {}
 }
 
+function readRecentConfigs() {
+  try {
+    const raw = localStorage.getItem(RECENT_CONFIGS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+function writeRecentConfigs(entries) {
+  try {
+    localStorage.setItem(RECENT_CONFIGS_KEY, JSON.stringify(Array.isArray(entries) ? entries : []));
+  } catch (_) {}
+}
+
+function saveRecentConfig(configId, configData) {
+  const cleanId = sanitizeConfigId(configId);
+  if (!cleanId) return;
+  const recent = readRecentConfigs().filter(entry => sanitizeConfigId(entry && entry.id) !== cleanId);
+  const clubs = [];
+  if (configData && configData.club) clubs.push(configData.club.name || configData.club.id || '');
+  if (configData && Array.isArray(configData.additionalClubs)) {
+    configData.additionalClubs.forEach(c => clubs.push(c.name || c.id || ''));
+  }
+  const label = clubs.filter(Boolean).slice(0, 2).join(' + ') || cleanId;
+  recent.unshift({
+    id: cleanId,
+    label,
+    usedAt: new Date().toISOString(),
+  });
+  writeRecentConfigs(recent.slice(0, 5));
+}
+
 function sanitizeConfigId(value) {
   return String(value || '').trim().toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 12);
 }
@@ -906,6 +941,8 @@ function loadConfigById(configId, compactMode = false) {
   const input = $('club-config-id-input');
   if (input) input.value = cleanId;
   updateUrlConfigParam(cleanId);
+  saveRecentConfig(cleanId, config);
+  renderRecentClubs();
   return true;
 }
 
@@ -927,9 +964,11 @@ function saveCurrentConfig() {
     updatedAt: new Date().toISOString(),
   };
   writeSavedConfigs(configs);
+  saveRecentConfig(configId, configs[configId]);
   updateUrlConfigParam(configId);
   if (input) input.value = configId;
   showConfigStatus('Konfiguration gespeichert: ' + configId);
+  renderRecentClubs();
 }
 
 // ===================== Recent Clubs =====================
@@ -954,16 +993,17 @@ function saveRecentClub(club) {
 
 function renderRecentClubs() {
   const container = $('recent-clubs');
-  const list = loadRecentClubs();
-  if (!list.length) { showEl(container, false); return; }
+  const clubs = loadRecentClubs();
+  const recentConfigs = readRecentConfigs();
+  if (!clubs.length && !recentConfigs.length) { showEl(container, false); return; }
   showEl(container, true);
   container.innerHTML =
     '<div class="recent-clubs-head">' +
       '<div class="recent-clubs-label">Zuletzt verwendet:</div>' +
       '<button type="button" class="recent-clubs-reset" id="recent-clubs-reset">zurücksetzen</button>' +
     '</div>' +
-    '<div class="recent-clubs-list">' +
-    list.map(club =>
+    (clubs.length ? '<div class="recent-sub-label">Vereine</div><div class="recent-clubs-list">' +
+    clubs.map(club =>
       '<button class="recent-club-btn" type="button" data-club-id="' + escapeHtml(club.id) + '" title="' + escapeHtml(club.name) + (club.location ? ' \u00b7 ' + escapeHtml(club.location) : '') + '">' +
       '<span class="recent-club-logo-wrap">' +
       (club.logoUrl
@@ -972,20 +1012,41 @@ function renderRecentClubs() {
       '</span>' +
       '<span class="recent-club-name">' + escapeHtml(club.name) + '</span>' +
       '</button>'
-    ).join('') +
-    '</div>';
+    ).join('') + '</div>' : '') +
+    (recentConfigs.length ? '<div class="recent-sub-label">Konfigurationen</div><div class="recent-clubs-list recent-configs-list">' +
+      recentConfigs.map(entry =>
+        '<button class="recent-club-btn recent-config-btn" type="button" data-config-id="' + escapeHtml(entry.id) + '" title="Konfiguration ' + escapeHtml(entry.id) + '">' +
+          '<span class="recent-config-id">' + escapeHtml(entry.id) + '</span>' +
+          '<span class="recent-club-name">' + escapeHtml(entry.label || entry.id) + '</span>' +
+        '</button>'
+      ).join('') +
+      '</div>' : '');
   const resetBtn = $('recent-clubs-reset');
   if (resetBtn) {
     resetBtn.addEventListener('click', () => {
       deleteCookie(COOKIE_RECENT);
+      localStorage.removeItem(RECENT_CONFIGS_KEY);
       clearClub();
       renderRecentClubs();
     });
   }
   container.querySelectorAll('[data-club-id]').forEach(button => {
     button.addEventListener('click', () => {
-      const club = list.find(c => c.id === button.dataset.clubId);
+      const club = clubs.find(c => c.id === button.dataset.clubId);
       if (club) selectClub(club);
+    });
+  });
+  container.querySelectorAll('[data-config-id]').forEach(button => {
+    button.addEventListener('click', () => {
+      const id = button.dataset.configId || '';
+      const ok = loadConfigById(id, true);
+      if (!ok) {
+        showConfigStatus('Konfiguration "' + id + '" wurde nicht gefunden.', true);
+      } else {
+        showConfigStatus('Konfiguration geladen: ' + id);
+        jumpToCalendar();
+        autoLoadGames();
+      }
     });
   });
 }
@@ -1620,6 +1681,7 @@ function renderVenueCheckboxes() {
   const emptyEl   = $('venues-empty');
   const cbEl      = $('venues-checkboxes');
   const errEl     = $('venues-error');
+  const wrapEl    = $('venues-selection-inline');
 
   showEl(loadingEl, false);
   showEl(errEl, false);
@@ -1627,19 +1689,20 @@ function renderVenueCheckboxes() {
   if (!state.club || !state.club.id) {
     emptyEl.textContent = 'Bitte zuerst einen Verein auswählen.';
     showEl(emptyEl, true);
-    showEl(cbEl, false);
+    showEl(wrapEl, false);
     return;
   }
 
   if (!state.venues.length) {
     emptyEl.textContent = 'Keine Spielstätten gefunden.';
     showEl(emptyEl, true);
-    showEl(cbEl, false);
+    showEl(wrapEl, false);
     return;
   }
 
   showEl(emptyEl, false);
-  showEl(cbEl, true);
+  showEl(wrapEl, true);
+  wrapEl.classList.toggle('venues-selection-inline--compact', state.view === 'month');
 
   const MAPS_BASE = 'https://www.google.com/maps/search/?api=1&query=';
 
@@ -1691,6 +1754,7 @@ function renderCurrentView() {
     state.currentMonth = new Date(t.getFullYear(), t.getMonth(), 1);
   }
   updateDatePicker();
+  renderVenueCheckboxes();
   if (state.view === 'week') {
     renderWeekView();
     showEl($('week-view'), true);
@@ -1727,13 +1791,19 @@ function renderWeekView() {
   });
 
   const visibleVenues = getVisibleVenues();
-  if (!state.games.length || !visibleVenues.length) {
+  if (!visibleVenues.length) {
     showEl($('no-games-msg'), true);
     showEl($('week-view'), false);
     return;
   }
 
-  showEl($('no-games-msg'), false);
+  const hasWeekGames = state.games.some(game => {
+    const vid = deriveVenueId(game);
+    if (!visibleVenues.find(v => v.id === vid)) return false;
+    const d = new Date(game.startDate);
+    return d >= weekStart && d <= weekEnd;
+  });
+  showEl($('no-games-msg'), !hasWeekGames);
 
   const weekGames = [];
 
@@ -1818,7 +1888,8 @@ function renderMonthView() {
   const listEl = $('month-list');
   listEl.innerHTML = '';
 
-  const visibleIds = new Set(getVisibleVenues().map(v => v.id));
+  const visibleVenues = getVisibleVenues();
+  const visibleIds = new Set(visibleVenues.map(v => v.id));
 
   const monthGames = state.games
     .filter(g => {
@@ -1833,7 +1904,10 @@ function renderMonthView() {
 
   if (!monthGames.length) {
     showEl($('no-games-msg'), true);
-    showEl($('month-view'), false);
+    const emptyMonth = document.createElement('div');
+    emptyMonth.className = 'empty-msg';
+    emptyMonth.textContent = 'Im gewählten Monat gibt es keine Termine auf den ausgewählten Spielstätten.';
+    listEl.appendChild(emptyMonth);
     return;
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -138,8 +138,8 @@
           <div class="team-overview-table"><span class="team-overview-name">SGM SKV Hochberg/SGV Hochdorf II</span><span class="team-overview-comp">E-Junioren | Kreisstaffel</span><span class="team-overview-actions"><button class="btn btn-sm" title="+ Training" aria-label="Training melden">+ Training</button></span></div>
         </div>
         </details>
-        <div class="config-actions">
-          <button id="save-club-config-btn" class="btn btn-secondary" type="button">Konfiguration speichern</button>
+        <div class="config-actions config-actions-subtle">
+          <button id="save-club-config-btn" class="btn btn-sm btn-quiet" type="button">speichern</button>
           <input
             type="text"
             id="club-config-id-input"
@@ -147,7 +147,7 @@
             placeholder="Konfig-ID"
             autocomplete="off"
           />
-          <button id="load-club-config-btn" class="btn btn-secondary" type="button">Konfiguration laden</button>
+          <button id="load-club-config-btn" class="btn btn-sm btn-quiet" type="button">laden</button>
         </div>
       </div>
       <div id="club-config-status" class="hint current-club hidden"></div>
@@ -156,29 +156,12 @@
       <!-- Modal is rendered at document root to avoid clipping and ensure correct overlay behavior -->
     </section>
 
-    <!-- Section 2: Spielstätten -->
-    <section class="panel section-step hidden" id="section-spielstaetten">
-      <h2 class="section-title">
-        <span class="section-num">2</span> Spielstätten
-        <span class="tooltip-wrap">
-          <button class="tooltip-btn" type="button" aria-label="Info">?</button>
-          <span class="tooltip-content">Spielstätten werden automatisch aus dem Vereinsspielplan ermittelt (nächste 2 Monate). Wähle ab, welche im Kalender erscheinen sollen – die Auswahl wird gespeichert.</span>
-        </span>
-      </h2>
-      <div id="venues-loading" class="loading hidden">
-        <span class="spinner"></span> Spielstätten werden geladen…
-      </div>
-      <div id="venues-empty" class="empty-msg">Bitte zuerst einen Verein auswählen.</div>
-      <div id="venues-checkboxes" class="venues-checkboxes hidden"></div>
-      <div id="venues-error" class="error-msg hidden"></div>
-    </section>
-
-    <!-- Section 3: Belegungskalender -->
+    <!-- Section 2: Belegungskalender -->
     <section class="panel hidden" id="section-kalender">
       <div class="panel-header">
         <div class="panel-header-top">
           <h2 class="section-title">
-            <span class="section-num">3</span> Belegungskalender
+            <span class="section-num">2</span> Belegungskalender
           </h2>
           <div class="view-controls">
             <button class="btn btn-sm btn-active" id="view-week-btn">Woche</button>
@@ -191,6 +174,19 @@
           <span id="current-period-label" class="week-label"></span>
           <button class="btn btn-sm" id="next-period-btn" aria-label="Weiter">&#8250;</button>
         </div>
+      </div>
+
+      <div id="venues-loading" class="loading hidden">
+        <span class="spinner"></span> Spielstätten werden geladen…
+      </div>
+      <div id="venues-empty" class="empty-msg">Bitte zuerst einen Verein auswählen.</div>
+      <div id="venues-error" class="error-msg hidden"></div>
+      <div id="venues-selection-inline" class="venues-selection-inline hidden">
+        <div class="venues-selection-head">
+          <span class="venues-selection-title">Spielstätten</span>
+          <span class="venues-selection-hint">Monat: kompakte Auswahl oben · Woche: Auswahl direkt im Kalender</span>
+        </div>
+        <div id="venues-checkboxes" class="venues-checkboxes"></div>
       </div>
 
       <div id="loading-indicator" class="loading hidden">

--- a/public/style.css
+++ b/public/style.css
@@ -535,6 +535,12 @@ main {
   gap: 0.5rem;
   flex-wrap: wrap;
 }
+.recent-sub-label {
+  font-size: 0.72rem;
+  color: var(--text-light);
+  margin: 0.2rem 0 0.35rem;
+  font-weight: 600;
+}
 .recent-clubs-reset {
   border: none;
   background: none;
@@ -602,6 +608,18 @@ main {
   white-space: nowrap;
   width: 100%;
 }
+.recent-config-btn {
+  align-items: flex-start;
+  min-width: 98px;
+  max-width: 160px;
+  padding: 0.45rem 0.55rem;
+}
+.recent-config-id {
+  font-size: 0.68rem;
+  color: var(--primary-d);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
 
 .selected-club-info {
   margin-top: 0.8rem;
@@ -655,6 +673,22 @@ main {
   align-items: center;
   gap: 0.5rem;
   flex-wrap: wrap;
+}
+.config-actions-subtle {
+  margin-top: 0.7rem;
+  padding: 0.45rem 0.55rem;
+  border: 1px dashed #c9d6e8;
+  border-radius: 9px;
+  background: #f8fbff;
+}
+.btn-quiet {
+  background: #eef3fb;
+  color: #4e617d;
+  border: 1px solid #d2deee;
+}
+.btn-quiet:hover {
+  background: #e3ecfa;
+  color: #2f4b72;
 }
 
 .config-id-input {
@@ -1116,6 +1150,36 @@ main {
 }
 .view-controls .btn {
   flex: 0 0 auto;
+}
+.venues-selection-inline {
+  margin: 0.55rem 0 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.45rem 0.55rem 0.55rem;
+  background: #f9fcff;
+}
+.venues-selection-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.35rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.venues-selection-title {
+  font-weight: 700;
+  font-size: 0.82rem;
+  color: var(--primary-d);
+}
+.venues-selection-hint {
+  font-size: 0.72rem;
+  color: var(--text-light);
+}
+.venues-selection-inline--compact .venue-full-name {
+  display: none;
+}
+.venues-selection-inline--compact .venue-checkbox-item {
+  padding: 0.22rem 0.4rem;
 }
 .nav-controls {
   display: flex;


### PR DESCRIPTION
### Motivation

- Provide a simple password-protected admin UI to inspect usage statistics, page hit counts and configuration without exposing secrets in the frontend. 
- Collect basic site metrics (page hits) to surface most-visited paths and overall traffic in the admin view. 
- Improve user experience by adding recent saved configuration shortcuts and making venue selection more compact and usable in month/week views.

### Description

- Backend: introduce `PAGE_HITS_FILE`, `loadPageHits()`, `savePageHits()`, `recordPageHit()`, `buildPageHitsResponse()` and `shouldTrackPageHit()` to count and persist page hits, and call `recordPageHit($uri)` for each request. 
- Backend: add `ensureStatsPasswordAuthorized()` helper and new password-protected endpoints `GET /api/admin/config`, `GET /api/admin/page-hits` and `GET /api/admin/dashboard` (dashboard returns stats, page hits and config together). 
- Frontend: add an admin UI with `public/admin.html` and `public/admin.js` to log in with the stats password and display parse stats, page hits and saved `config.yaml` content. 
- Frontend/app: add recent saved-configuration support (`RECENT_CONFIGS_KEY`) with `saveRecentConfig()`, `readRecentConfigs()` and UI integration to show recent configs, adjust venue-selection into an inline block for the calendar, and various UI/CSS changes in `public/index.html`, `public/app.js` and `public/style.css` for compact buttons and venue-selection behavior. 
- Docs: expose the new admin page and new admin API endpoints in `README.md`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d8db6bf88320bfa9197c338e0391)