### PR TITLE
Refine admin dashboard and calendar venue selection behavior

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -30,7 +30,6 @@
         <input id="password" type="password" placeholder="Admin-Passwort" />
         <button id="load">Daten laden</button>
       </div>
-      <div class="muted">Verwendet das gleiche Passwort wie <code>/api/admin/club-parse-stats</code>.</div>
       <div id="error" class="error"></div>
     </div>
 
@@ -56,6 +55,15 @@
       <div class="card">
         <h2>Gespeicherte Konfiguration</h2>
         <pre id="config-json"></pre>
+      </div>
+
+      <div class="card">
+        <h2>Aufgerufene Konfigurationen</h2>
+        <div id="config-hits-meta" class="muted"></div>
+        <table>
+          <thead><tr><th>Konfig-ID</th><th>Aufrufe</th><th>Link</th></tr></thead>
+          <tbody id="config-hits-body"></tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/public/admin.js
+++ b/public/admin.js
@@ -16,14 +16,91 @@
     body.innerHTML = '';
     (stats.clubs || []).forEach((club) => {
       const tr = document.createElement('tr');
-      tr.innerHTML = '<td>' + (club.name || '-') + '</td>' +
-        '<td><code>' + (club.id || '-') + '</code></td>' +
-        '<td>' + (club.parses || 0) + '</td>' +
-        '<td>' + fmt(club.lastParsedAt) + '</td>';
+
+      const nameCell = document.createElement('td');
+      nameCell.textContent = club.name || '-';
+
+      const idCell = document.createElement('td');
+      const code = document.createElement('code');
+      code.textContent = club.id || '-';
+      idCell.appendChild(code);
+
+      const parsesCell = document.createElement('td');
+      parsesCell.textContent = String(club.parses || 0);
+
+      const lastParsedCell = document.createElement('td');
+      lastParsedCell.textContent = fmt(club.lastParsedAt);
+
+      tr.appendChild(nameCell);
+      tr.appendChild(idCell);
+      tr.appendChild(parsesCell);
+      tr.appendChild(lastParsedCell);
       body.appendChild(tr);
     });
     $('stats-meta').textContent = 'Gesamt: ' + (stats.totalParses || 0) + ' Parses, ' +
       (stats.totalClubs || 0) + ' Vereine, aktualisiert: ' + fmt(stats.updatedAt);
+  }
+
+  function parseConfigHits(paths) {
+    const counts = new Map();
+    (paths || []).forEach((row) => {
+      const rawPath = String(row.path || '');
+      const hits = Number(row.hits || 0);
+      let url;
+      try {
+        url = new URL(rawPath, window.location.origin);
+      } catch (e) {
+        return;
+      }
+      const configId = (url.searchParams.get('config') || '').trim();
+      if (!configId) return;
+      counts.set(configId, (counts.get(configId) || 0) + hits);
+    });
+    return Array.from(counts.entries())
+      .map(([configId, hits]) => ({ configId, hits }))
+      .sort((a, b) => b.hits - a.hits || a.configId.localeCompare(b.configId));
+  }
+
+  function renderConfigHits(hits) {
+    const rows = parseConfigHits(hits.paths);
+    const body = $('config-hits-body');
+    body.innerHTML = '';
+
+    if (!rows.length) {
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 3;
+      td.textContent = 'Keine aufgerufenen Konfigurationen gefunden.';
+      tr.appendChild(td);
+      body.appendChild(tr);
+    } else {
+      rows.forEach((row) => {
+        const tr = document.createElement('tr');
+
+        const idCell = document.createElement('td');
+        const idCode = document.createElement('code');
+        idCode.textContent = row.configId;
+        idCell.appendChild(idCode);
+
+        const hitsCell = document.createElement('td');
+        hitsCell.textContent = String(row.hits);
+
+        const linkCell = document.createElement('td');
+        const link = document.createElement('a');
+        link.href = '/?config=' + encodeURIComponent(row.configId);
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.textContent = 'öffnen';
+        linkCell.appendChild(link);
+
+        tr.appendChild(idCell);
+        tr.appendChild(hitsCell);
+        tr.appendChild(linkCell);
+        body.appendChild(tr);
+      });
+    }
+
+    $('config-hits-meta').textContent = 'Gefundene Konfigurationen: ' + rows.length;
   }
 
   function renderHits(hits) {
@@ -31,10 +108,20 @@
     body.innerHTML = '';
     (hits.paths || []).forEach((row) => {
       const tr = document.createElement('tr');
-      tr.innerHTML = '<td><code>' + (row.path || '/') + '</code></td><td>' + (row.hits || 0) + '</td>';
+      const pathCell = document.createElement('td');
+      const code = document.createElement('code');
+      code.textContent = row.path || '/';
+      pathCell.appendChild(code);
+
+      const hitsCell = document.createElement('td');
+      hitsCell.textContent = String(row.hits || 0);
+
+      tr.appendChild(pathCell);
+      tr.appendChild(hitsCell);
       body.appendChild(tr);
     });
     $('hits-meta').textContent = 'Gesamt: ' + (hits.total || 0) + ' Hits, aktualisiert: ' + fmt(hits.updatedAt);
+    renderConfigHits(hits);
   }
 
   async function loadDashboard() {

--- a/public/app.js
+++ b/public/app.js
@@ -1679,9 +1679,12 @@ function reconcileVenueSelection() {
 function renderVenueCheckboxes() {
   const loadingEl = $('venues-loading');
   const emptyEl   = $('venues-empty');
-  const cbEl      = $('venues-checkboxes');
+  const monthCbEl = $('venues-checkboxes');
+  const weekCbEl  = $('week-venues-checkboxes');
   const errEl     = $('venues-error');
-  const wrapEl    = $('venues-selection-inline');
+  const monthWrapEl = $('venues-selection-inline');
+  const isWeekView = state.view === 'week';
+  const cbEl = isWeekView ? weekCbEl : monthCbEl;
 
   showEl(loadingEl, false);
   showEl(errEl, false);
@@ -1689,34 +1692,36 @@ function renderVenueCheckboxes() {
   if (!state.club || !state.club.id) {
     emptyEl.textContent = 'Bitte zuerst einen Verein auswählen.';
     showEl(emptyEl, true);
-    showEl(wrapEl, false);
+    showEl(monthWrapEl, false);
+    if (weekCbEl) weekCbEl.innerHTML = '';
     return;
   }
 
   if (!state.venues.length) {
     emptyEl.textContent = 'Keine Spielstätten gefunden.';
     showEl(emptyEl, true);
-    showEl(wrapEl, false);
+    showEl(monthWrapEl, false);
+    if (weekCbEl) weekCbEl.innerHTML = '';
     return;
   }
 
   showEl(emptyEl, false);
-  showEl(wrapEl, true);
-  wrapEl.classList.toggle('venues-selection-inline--compact', state.view === 'month');
+  showEl(monthWrapEl, !isWeekView);
+  monthWrapEl.classList.toggle('venues-selection-inline--compact', !isWeekView);
+  if (weekCbEl) showEl(weekCbEl, isWeekView);
+  if (!cbEl) return;
 
   const MAPS_BASE = 'https://www.google.com/maps/search/?api=1&query=';
 
   cbEl.innerHTML = state.venues.map((venue, index) => {
     const color   = VENUE_COLORS[index % VENUE_COLORS.length];
     const checked = isVenueSelected(venue.id) ? 'checked' : '';
-    const short   = state.venueShortNames[venue.id] || deriveShortVenueName(venue.name);
     const mapsUrl = MAPS_BASE + encodeURIComponent(venue.name);
     return (
       '<label class="venue-checkbox-item">' +
       '<input type="checkbox" data-venue-id="' + escapeHtml(venue.id) + '" ' + checked + ' />' +
       '<span class="venue-color-dot" style="background:' + color + '"></span>' +
-      '<span class="venue-short-name">' + escapeHtml(short) + '</span>' +
-      '<span class="venue-full-name" title="' + escapeHtml(venue.name) + '">' + escapeHtml(venue.name) + '</span>' +
+      '<span class="venue-name" title="' + escapeHtml(venue.name) + '">' + escapeHtml(venue.name) + '</span>' +
       '<a class="venue-map-icon" href="' + escapeHtml(mapsUrl) + '" target="_blank" rel="noopener noreferrer" title="In Google Maps öffnen" onclick="event.stopPropagation()">&#x1F4CD;</a>' +
       '</label>'
     );
@@ -1770,7 +1775,7 @@ function renderWeekView() {
   const weekStart = state.currentWeekStart;
   const days      = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   const today     = new Date();
-  const weekEnd   = days[6];
+  const weekEndExclusive = addDays(days[6], 1);
 
   // Label shows "KW XX · YYYY"
   $('current-period-label').textContent =
@@ -1801,7 +1806,7 @@ function renderWeekView() {
     const vid = deriveVenueId(game);
     if (!visibleVenues.find(v => v.id === vid)) return false;
     const d = new Date(game.startDate);
-    return d >= weekStart && d <= weekEnd;
+    return d >= weekStart && d < weekEndExclusive;
   });
   showEl($('no-games-msg'), !hasWeekGames);
 

--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,7 @@
     <!-- Section 1: Verein -->
     <section class="panel section-step" id="section-verein">
       <h2 class="section-title">
-        <span class="section-num">1</span> Verein
+        Verein
         <span class="tooltip-wrap">
           <button class="tooltip-btn" type="button" aria-label="Info">?</button>
           <span class="tooltip-content">Vereinslink von fussball.de einfügen oder Vereinsnamen eingeben. Die Auswahl wird im Browser gespeichert (Cookie).</span>
@@ -161,7 +161,7 @@
       <div class="panel-header">
         <div class="panel-header-top">
           <h2 class="section-title">
-            <span class="section-num">2</span> Belegungskalender
+            Belegungskalender
           </h2>
           <div class="view-controls">
             <button class="btn btn-sm btn-active" id="view-week-btn">Woche</button>
@@ -184,7 +184,7 @@
       <div id="venues-selection-inline" class="venues-selection-inline hidden">
         <div class="venues-selection-head">
           <span class="venues-selection-title">Spielstätten</span>
-          <span class="venues-selection-hint">Monat: kompakte Auswahl oben · Woche: Auswahl direkt im Kalender</span>
+          <span class="venues-selection-hint">Monat: kompakte Auswahl oben</span>
         </div>
         <div id="venues-checkboxes" class="venues-checkboxes"></div>
       </div>
@@ -199,6 +199,7 @@
         <div class="week-grid-wrap">
           <div class="week-grid" id="week-grid"></div>
         </div>
+        <div id="week-venues-checkboxes" class="week-venues-checkboxes"></div>
       </div>
 
       <!-- Month view -->

--- a/public/style.css
+++ b/public/style.css
@@ -1045,13 +1045,8 @@ main {
   border-radius: 50%;
   flex-shrink: 0;
 }
-.venue-short-name {
-  font-weight: 700;
-  font-size: 0.88rem;
-  flex-shrink: 0;
-}
-.venue-full-name {
-  font-size: 0.78rem;
+.venue-name {
+  font-size: 0.84rem;
   color: var(--text-light);
   flex: 1;
   min-width: 0;
@@ -1175,11 +1170,16 @@ main {
   font-size: 0.72rem;
   color: var(--text-light);
 }
-.venues-selection-inline--compact .venue-full-name {
-  display: none;
-}
 .venues-selection-inline--compact .venue-checkbox-item {
-  padding: 0.22rem 0.4rem;
+  padding: 0.2rem 0.35rem;
+}
+.venues-selection-inline--compact .venues-checkboxes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.22rem 0.45rem;
+}
+.venues-selection-inline--compact .venue-name {
+  font-size: 0.8rem;
 }
 .nav-controls {
   display: flex;
@@ -1204,6 +1204,16 @@ main {
 .week-grid-wrap {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+}
+.week-venues-checkboxes {
+  margin-top: 0.55rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.25rem 0.5rem;
+}
+.week-venues-checkboxes .venue-checkbox-item {
+  padding: 0.3rem 0.42rem;
+  background: #f8fbf8;
 }
 
 /* Week Grid */


### PR DESCRIPTION
### Motivation
- Remove an admin UI hint that exposed which password to use and add visibility into which saved `?config=...` links are being accessed.  
- Fix XSS surface in the admin tables by avoiding `innerHTML` with server-provided values.  
- Improve calendar venue-selection UX: keep month view compact without truncating names, move venue checkboxes into the week view, and ensure Sunday fixtures are counted when checking an empty week.  

### Description
- Admin UI: removed the password hint from `public/admin.html` and added a new "Aufgerufene Konfigurationen" table that aggregates `?config=...` hits (new DOM rendering functions `parseConfigHits` and `renderConfigHits` in `public/admin.js`).  
- Security: replaced unsafe `innerHTML` usage in `public/admin.js` with DOM creation + `textContent` for all table cells to prevent stored XSS.  
- Calendar UI: removed numeric section badges in `public/index.html`, kept full venue names in the compact month selection, and moved the venue checkbox block into the week view by adding `#week-venues-checkboxes` and switching rendering between month and week in `public/app.js`.  
- Layout/CSS: updated `public/style.css` to provide a compact grid layout for month compact mode and a dedicated layout for week checkboxes.  
- Logic: fixed week emptiness check in `public/app.js` to include Sunday fixtures by using an exclusive `weekEndExclusive` (`addDays(days[6], 1)`) so `d >= weekStart && d < weekEndExclusive`.  

### Testing
- Ran `node --check public/app.js` with no syntax errors.  
- Ran `node --check public/admin.js` with no syntax errors.  
- Ran `php -l backend.php` with no syntax errors.  
All automated lint/syntax checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f44169188320bc06ed37c0f19f86)