### PR TITLE
Restrict releases to main and decouple deploy from scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Wenn der Hoster kein SSH anbietet, genügt bereits ein FTP-Client wie FileZilla,
 
 #### Release per Skript
 
-Für versionierte Releases gibt es zusätzlich ein Release-Skript. Es synchronisiert die relevanten Versionsdateien, erstellt Commit + Tag, pusht beides und legt anschließend ein GitHub Release mit automatisch generierten Notes an.
+Für versionierte Releases gibt es zusätzlich ein Release-Skript. Es synchronisiert die relevanten Versionsdateien, erstellt Commit + Tag, pusht beides und legt anschließend ein GitHub Release mit automatisch generierten Notes an. Releases sind dabei nur auf dem Branch `main` erlaubt.
 
 ```bash
 bash scripts/release.sh v0.1.71
@@ -280,10 +280,11 @@ bash scripts/deploy.sh /pfad/zu/meiner.deploy.env
 
 #### Was das Skript macht
 
-- führt optional `platzbelegung scrape` aus
-- lädt `public/`, `backend.php` und `data/latest.json` hoch
+- lädt `public/`, `backend.php` und Build-Metadaten hoch
 - lädt optional zusätzlich `config.yaml`, `.htaccess` und `data/latest.html` hoch
 - unterstützt `ftp`, `ftps`, `sftp` und `rsync`
+
+Hinweis: `data/latest.json` wird bewusst nicht mehr durch das Deploy-Skript erzeugt oder hochgeladen, weil das Scraping separat (z. B. via MSZ) gemanagt wird.
 
 #### Wichtige Dateien für das Skript
 

--- a/deploy.example.env
+++ b/deploy.example.env
@@ -28,9 +28,6 @@ DEPLOY_PASS=CHANGE_ME
 # Zielordner auf dem Server, z.B. /www/htdocs/w00abcde/platzbelegung
 DEPLOY_REMOTE_DIR=/path/to/subdomain-root
 
-# Vor dem Upload automatisch neue Daten scrapen
-SCRAPE_BEFORE_UPLOAD=1
-
 # Optional zusätzlich data/latest.html erzeugen und hochladen
 GENERATE_HTML=0
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,7 +31,6 @@ is_true() {
 DEPLOY_METHOD="${DEPLOY_METHOD:-ftps}"
 DEPLOY_PORT="${DEPLOY_PORT:-}"
 DEPLOY_REMOTE_DIR="${DEPLOY_REMOTE_DIR:-}"
-SCRAPE_BEFORE_UPLOAD="${SCRAPE_BEFORE_UPLOAD:-1}"
 GENERATE_HTML="${GENERATE_HTML:-0}"
 UPLOAD_CONFIG="${UPLOAD_CONFIG:-1}"
 UPLOAD_HTACCESS="${UPLOAD_HTACCESS:-1}"
@@ -136,19 +135,9 @@ echo "==> Deploy-Methode: $DEPLOY_METHOD"
 echo "==> Ziel: ${DEPLOY_HOST}:${DEPLOY_REMOTE_DIR}"
 echo "==> Verwende CLI: $PLATZBELEGUNG_CMD"
 
-if is_true "$SCRAPE_BEFORE_UPLOAD"; then
-  echo "==> Erzeuge aktuellen Snapshot"
-  run_platzbelegung scrape
-fi
-
 if is_true "$GENERATE_HTML"; then
   echo "==> Erzeuge HTML-Ausgabe"
   run_platzbelegung html
-fi
-
-if [[ ! -f "$ROOT_DIR/data/latest.json" ]]; then
-  echo "data/latest.json fehlt. Bitte zuerst 'platzbelegung scrape' ausführen." >&2
-  exit 1
 fi
 
 BASE_VERSION="$(tr -d '[:space:]' < "$ROOT_DIR/VERSION" 2>/dev/null || printf 'dev')"
@@ -273,7 +262,6 @@ EOF
   fi
 
   lftp_script+=$'\n'"put -O $DEPLOY_REMOTE_DIR BUILD_META.json"
-  lftp_script+=$'\n'"put -O $remote_data_dir data/latest.json"
 
   if is_true "$GENERATE_HTML" && [[ -f "$ROOT_DIR/data/latest.html" ]]; then
     lftp_script+=$'\n'"put -O $remote_data_dir data/latest.html"
@@ -322,9 +310,6 @@ upload_with_rsync() {
 
   echo "==> Lade BUILD_META.json hoch"
   rsync -av -e "$ssh_cmd" "$BUILD_META_PATH" "$remote:$DEPLOY_REMOTE_DIR/BUILD_META.json"
-
-  echo "==> Lade data/latest.json hoch"
-  rsync -av -e "$ssh_cmd" "$ROOT_DIR/data/latest.json" "$remote:$DEPLOY_REMOTE_DIR/data/latest.json"
 
   if is_true "$GENERATE_HTML" && [[ -f "$ROOT_DIR/data/latest.html" ]]; then
     echo "==> Lade data/latest.html hoch"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,6 +36,15 @@ require_clean_worktree() {
   fi
 }
 
+require_main_branch() {
+  local current_branch
+  current_branch="$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [[ "$current_branch" != "main" ]]; then
+    echo "Releases sind nur auf Branch 'main' erlaubt. Aktueller Branch: ${current_branch:-unbekannt}" >&2
+    exit 1
+  fi
+}
+
 gh_safe() {
   env -u GITHUB_TOKEN gh "$@"
 }
@@ -116,6 +125,7 @@ require_tool git
 require_tool gh
 require_tool python3
 require_clean_worktree
+require_main_branch
 ensure_version_not_exists
 
 update_version_files


### PR DESCRIPTION
### Motivation

- Prevent accidental releases from branches other than `main` by enforcing a branch check in the release workflow.  
- Decouple snapshot/scraping lifecycle from the deploy step so snapshots are managed externally (e.g. via MSZ).  
- Keep the deploy script focused on application files and build metadata rather than generating or uploading snapshots.

### Description

- Added a `require_main_branch()` check to `scripts/release.sh` and invoke it before creating a release so releases only run on branch `main`.  
- Removed automatic scraping from `scripts/deploy.sh` by deleting the `SCRAPE_BEFORE_UPLOAD` option and the `platzbelegung scrape` call.  
- Stopped uploading `data/latest.json` in both the LFTP and rsync upload paths; deploy now uploads `BUILD_META.json` and application files (and optional `data/latest.html`).  
- Updated `deploy.example.env` to remove the `SCRAPE_BEFORE_UPLOAD` setting and updated `README.md` to note that releases are `main`-only and that `data/latest.json` is intentionally not produced/uploaded by the deploy script (scraping is expected to be managed separately).

### Testing

- Ran `bash -n scripts/release.sh` to validate shell syntax; result: success.  
- Ran `bash -n scripts/deploy.sh` to validate shell syntax; result: success.  
- Verified removal of automatic scraping and snapshot upload via search: `rg -n "SCRAPE_BEFORE_UPLOAD|platzbelegung scrape" scripts/deploy.sh deploy.example.env README.md`; result: matched expected updates (no scraping invocation in deploy script).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb11a50d1c83208389a5c390b5d738)